### PR TITLE
Add pace µe mod v0.2.0

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -206,5 +206,32 @@
             "DS"
         ],
         "authorName": "Dean Nordhielm (with an assist from Tim Busick)"
+    },
+    {
+        "id": "6565179d-7c01-4bbd-bd44-fb5f24ff791b",
+        "name": "pace µe",
+        "description": "Displays the **µ pacing metric** derived from power, speed, and gradient during Zwift rides.\n\n* Hold µ constant for optimal pacing on hills and flats\n* Configurable sub-fields: power, speed, grade, cadence, HR, draft, wBal, Δa\n* Power smoothing: 1s / 3s / 7s\n* Auto or manual bike/wheel detection\n* Patreon-linked key for full access — free monthly beta keys available",
+        "created": 1783088983830,
+        "logoURL": "https://paceme-web-495541013056.europe-west1.run.app/static/logo.webp",
+        "homeURL": "https://www.patreon.com/paceme",
+        "authorName": "Hendrik Rommeswinkel",
+        "authorURL": "https://rommeswinkel.gitlab.io",
+        "authorAvatarURL": "https://paceme-web-495541013056.europe-west1.run.app/static/avatar.webp",
+        "tags": [
+            "time trial",
+            "pacing",
+            "data field"
+        ],
+        "releases": [
+            {
+                "version": "0.2.0",
+                "hash": "7ee56987dcec32df2e8bdbf02b5cfbc5c94a4669bbdb5518f6d1a935ae607a76",
+                "url": "https://mod-api.sauce.llc/assets/pace_e/7ee56987dcec32df2e8bdbf02b5cfbc5c94a4669bbdb5518f6d1a935ae607a76.zip",
+                "size": 34817,
+                "updated": 1783088983830,
+                "notes": "Faster bike & wheel selection (category-based), acceleration-based model comparison (Δa), level-picker buttons, and settings-panel fixes.",
+                "minVersion": "2.2.0"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Adds **pace µe** — a Zwift pacing overlay that shows the µ pacing metric derived from power, speed, and gradient; hold µ constant for optimal pacing on hills and flats. Free monthly beta keys; Patreon-linked for full access.

The v0.2.0 asset was uploaded to the Sauce mod CDN and its SHA-256 hash verified via the standard release script.